### PR TITLE
Fix an issue with corrupted tabset control bg

### DIFF
--- a/Lyte.sublime-theme
+++ b/Lyte.sublime-theme
@@ -41,7 +41,6 @@
 	{
 		// Tabset control scrolling
 		"class": "tabset_control",
-		"layer0.opacity": 0,
 		"settings": ["mouse_wheel_switches_tabs"],
 		"mouse_wheel_switch": true
 	},


### PR DESCRIPTION
In ST3 build 2059, I found on my Linux box that the tabset controls background was corrupted most of the time, showing random graphical data, previously closed tabs, etc.

Removing one line from the theme fixed this.
