### PR TITLE
In Lyte Dark color scheme, increase contrast for selection and Find

### DIFF
--- a/Lyte-Dark/Lyte-Dark.tmTheme
+++ b/Lyte-Dark/Lyte-Dark.tmTheme
@@ -23,11 +23,11 @@
                 <key>lineHighlight</key>
                 <string>#272727</string>
                 <key>selection</key>
-                <string>#f9267264</string>
+                <string>#424242</string>
                 <key>selectionBorder</key>
-                <string>#323232</string>
+                <string>#686868</string>
                 <key>findHighlight</key>
-                <string>#323232</string>
+                <string>#f9267288</string>
                 <key>findHighlightForeground</key>
                 <string>#fafafa</string>
                 <key>activeGuide</key>


### PR DESCRIPTION
I've been really enjoying using the Lyte theme and Lyte Dark color scheme for the last few weeks. It's replaced my old choice of theme and scheme, Soda Dark and Tomorrow Night Bright.

However, the new color scheme is less functional for me than Tomorrow Night was in one crucial respect: It's difficult for me to spot selected text and, especially, text highlighted in Find mode. I've created this branch in an attempt to remedy that.
### Before
#### Selection

![image](https://cloud.githubusercontent.com/assets/224895/6925632/c162dc88-d7ae-11e4-8b5f-e627f1be906c.png)

The dark red background doesn't have a lot of contrast against the black background, especially when the selected text has a similar color, like the orange you see here.
#### Find

![image](https://cloud.githubusercontent.com/assets/224895/6925670/fb93b4d6-d7ae-11e4-81d3-5567cbe79695.png)

The background change here is very subtle. The foreground change doesn't help much because white text is common in most syntaxes.
### After
#### Selection

![image](https://cloud.githubusercontent.com/assets/224895/6925828/3ac56626-d7b0-11e4-9e8d-f16532c0d966.png)

The grey background and lighter border make selected text easier to spot regardless of the color of text.
#### Find

![image](https://cloud.githubusercontent.com/assets/224895/6925845/5c70cd2e-d7b0-11e4-9c7c-72d2627c3de4.png)

The red background in combination with the white foreground ensure that there is very high contrast. I find that this lets me see the next selection instantly when I trigger "Find Next," rather than having to actively look for it.
